### PR TITLE
Implement sync of specific events

### DIFF
--- a/app/src/main/java/org/smartregister/addo/dao/EventDao.java
+++ b/app/src/main/java/org/smartregister/addo/dao/EventDao.java
@@ -61,14 +61,14 @@ public class EventDao extends AbstractDao {
     }
 
     /**
-     * Deletes an event from the database by its event ID.
+     * Deletes an event from the database by its event Type.
      * This method deletes the event with the specified event ID from the event table in the database.
      *
-     * @param eventId The ID of the event to be deleted. Must not be null.
-     *                The event with the specified ID will be removed from the database.
+     * @param eventType The event type to be deleted. Must not be null.
+     *                The event with the specified Type will be removed from the database.
      */
-    public static void deleteEventByEventId(String eventId) {
-        String sql2 = "delete from event where eventId = '" + eventId + "'";
+    public static void deleteEventByEventType(String eventType) {
+        String sql2 = "delete from event where eventType = '" + eventType + "'";
         updateDB(sql2);
     }
 }

--- a/app/src/main/java/org/smartregister/addo/dao/EventDao.java
+++ b/app/src/main/java/org/smartregister/addo/dao/EventDao.java
@@ -59,4 +59,16 @@ public class EventDao extends AbstractDao {
 
         return null;
     }
+
+    /**
+     * Deletes an event from the database by its event ID.
+     * This method deletes the event with the specified event ID from the event table in the database.
+     *
+     * @param eventId The ID of the event to be deleted. Must not be null.
+     *                The event with the specified ID will be removed from the database.
+     */
+    public static void deleteEventByEventId(String eventId) {
+        String sql2 = "delete from event where eventId = '" + eventId + "'";
+        updateDB(sql2);
+    }
 }

--- a/app/src/main/java/org/smartregister/addo/sync/AddoClientProcessor.java
+++ b/app/src/main/java/org/smartregister/addo/sync/AddoClientProcessor.java
@@ -1,9 +1,12 @@
 package org.smartregister.addo.sync;
 
+import static org.smartregister.addo.util.Constants.EventType;
+
 import android.content.ContentValues;
 import android.content.Context;
 
 import org.apache.commons.lang3.StringUtils;
+import org.smartregister.addo.dao.EventDao;
 import org.smartregister.chw.anc.util.DBConstants;
 import org.smartregister.chw.anc.util.NCUtils;
 import org.smartregister.addo.application.AddoApplication;
@@ -103,6 +106,19 @@ public class AddoClientProcessor extends ClientProcessorForJava {
 
     protected void processEvents(ClientClassification clientClassification, Table vaccineTable, Table serviceTable, EventClient eventClient, Event event, String eventType) throws Exception {
         switch (eventType) {
+            case EventType.KVP_PREP_FOLLOWUP_VISIT:
+            case EventType.AGYW_BIO_MEDICAL_SERVICES:
+            case EventType.AGYW_BEHAVIORAL_SERVICES:
+            case EventType.AGYW_STRUCTURAL_SERVICES:
+            case EventType.CBHS_CLOSE_VISITS:
+            case EventType.CBHS_FOLLOWUP:
+            case EventType.UPDATE_CBHS_REGISTRATION:
+            case EventType.MOTHER_CHAMPION_SBCC_SESSIONS:
+            case EventType.MOTHER_CHAMPION_FOLLOWUP:
+                // List of events that are not used by the ADDO app that can be deleted
+                // This list should be updated over time to improve app performance
+                deleteUnusedEvents(event);
+                break;
             case VaccineIntentService.EVENT_TYPE:
             case RecurringIntentService.EVENT_TYPE:
                 if (serviceTable == null) {
@@ -526,6 +542,21 @@ public class AddoClientProcessor extends ClientProcessorForJava {
 
             // Utils.context().commonrepository(CoreConstants.TABLE_NAME.CHILD).populateSearchValues(baseEntityId, DBConstants.KEY.DATE_REMOVED, new SimpleDateFormat("yyyy-MM-dd").format(eventDate), null);
 
+        }
+    }
+
+
+    /**
+     * Deletes the unused events from the database.
+     * This method deletes an event from the database based on its event ID, if the event is deemed unused.
+     * Unused events are those events that are not required by the ADDO app and can be safely deleted.
+     *
+     * @param event The event to be deleted. Must not be null.
+     *              The event object should contain the event ID to identify the event to be deleted.
+     */
+    private void deleteUnusedEvents(Event event) {
+        if (event != null && event.getEventId() != null) {
+            EventDao.deleteEventByEventId(event.getEventId());
         }
     }
 }

--- a/app/src/main/java/org/smartregister/addo/sync/AddoClientProcessor.java
+++ b/app/src/main/java/org/smartregister/addo/sync/AddoClientProcessor.java
@@ -106,6 +106,15 @@ public class AddoClientProcessor extends ClientProcessorForJava {
 
     protected void processEvents(ClientClassification clientClassification, Table vaccineTable, Table serviceTable, EventClient eventClient, Event event, String eventType) throws Exception {
         switch (eventType) {
+            case EventType.KVP_PrEP_REGISTRATION:
+            case EventType.PrEP_FOLLOWUP_VISIT:
+            case EventType.KVP_REGISTRATION:
+            case EventType.PrEP_REGISTRATION:
+            case EventType.KVP_BIO_MEDICAL_SERVICE_VISIT:
+            case EventType.KVP_BEHAVIORAL_SERVICE_VISIT:
+            case EventType.KVP_STRUCTURAL_SERVICE_VISIT:
+            case EventType.KVP_OTHER_SERVICE_VISIT:
+            case EventType.PrEP_CLIENT_NOT_ELIGIBLE:
             case EventType.KVP_PREP_FOLLOWUP_VISIT:
             case EventType.AGYW_BIO_MEDICAL_SERVICES:
             case EventType.AGYW_BEHAVIORAL_SERVICES:
@@ -548,15 +557,15 @@ public class AddoClientProcessor extends ClientProcessorForJava {
 
     /**
      * Deletes the unused events from the database.
-     * This method deletes an event from the database based on its event ID, if the event is deemed unused.
+     * This method deletes an event from the database based on its event Type, if the event is deemed unused.
      * Unused events are those events that are not required by the ADDO app and can be safely deleted.
      *
      * @param event The event to be deleted. Must not be null.
      *              The event object should contain the event ID to identify the event to be deleted.
      */
     private void deleteUnusedEvents(Event event) {
-        if (event != null && event.getEventId() != null) {
-            EventDao.deleteEventByEventId(event.getEventId());
+        if (event != null && event.getEventType() != null) {
+            EventDao.deleteEventByEventType(event.getEventType());
         }
     }
 }

--- a/app/src/main/java/org/smartregister/addo/util/Constants.java
+++ b/app/src/main/java/org/smartregister/addo/util/Constants.java
@@ -316,6 +316,28 @@ public class Constants {
         public static final String ANC_HOME_VISIT = "ANC Home Visit";
         public static final String UPDATE_ANC_REGISTRATION = "Update ANC Registration";
         public static final String PREGNANCY_OUTCOME = "Pregnancy Outcome";
+
+        public static final String ANC_FIRST_FACILITY_VISIT = "ANC First Facility Visit";
+
+        public static final String ANC_RECURRING_FACILITY_VISIT = "ANC Recurring Facility Visit";
+
+        public static final String MOTHER_CHAMPION_FOLLOWUP = "Mother Champion Followup";
+
+        public static final String MOTHER_CHAMPION_SBCC_SESSIONS = "Mother Champion SBCC Sessions";
+
+        public static final String CBHS_FOLLOWUP = "CBHS Followup";
+
+        public static final String CBHS_CLOSE_VISITS = "CBHS Close Visits";
+
+        public static final String UPDATE_CBHS_REGISTRATION = "Update CBHS Registration";
+
+        public static final String AGYW_STRUCTURAL_SERVICES = "AGYW Structural Services";
+
+        public static final String AGYW_BEHAVIORAL_SERVICES = "AGYW Behavioral Services";
+
+        public static final String AGYW_BIO_MEDICAL_SERVICES = "AGYW Bio Medical Services";
+
+        public static final String KVP_PREP_FOLLOWUP_VISIT = "Kvp PrEP Follow-up Visit";
     }
 
     public static class RELATIONSHIP {

--- a/app/src/main/java/org/smartregister/addo/util/Constants.java
+++ b/app/src/main/java/org/smartregister/addo/util/Constants.java
@@ -338,6 +338,24 @@ public class Constants {
         public static final String AGYW_BIO_MEDICAL_SERVICES = "AGYW Bio Medical Services";
 
         public static final String KVP_PREP_FOLLOWUP_VISIT = "Kvp PrEP Follow-up Visit";
+
+        public static final String KVP_PrEP_REGISTRATION = "KVP PrEP Registration";
+
+        public static final String PrEP_FOLLOWUP_VISIT = "PrEP Follow-up Visit";
+
+        public static final String KVP_REGISTRATION = "KVP Registration";
+
+        public static final String PrEP_REGISTRATION = "PrEP Registration";
+
+        public static final String KVP_BIO_MEDICAL_SERVICE_VISIT = "KVP Bio Medical Service Visit";
+
+        public static final String KVP_BEHAVIORAL_SERVICE_VISIT = "KVP Behavioral Service Visit";
+
+        public static final  String KVP_STRUCTURAL_SERVICE_VISIT = "KVP Structural Service Visit";
+
+        public static final String KVP_OTHER_SERVICE_VISIT = "KVP Other Service Visit";
+
+        public static final String PrEP_CLIENT_NOT_ELIGIBLE = "PrEP Client Not Eligible";
     }
 
     public static class RELATIONSHIP {


### PR DESCRIPTION
Closes [Issue](https://github.com/Digital-Square-Tanzania/opensrp-client-addo/issues/2)

This has been implemented on the client side. Implementing this on the server side would require much more work to pass the list of event types that should be synced, and the implementation would achieve a similar result.

Non-required events are deleted from the events table to improve performance.
**Changes made**:
- Updated AddoClientProcessor to detele unused events